### PR TITLE
Remove with value matching

### DIFF
--- a/FastCache/FastCache.cs
+++ b/FastCache/FastCache.cs
@@ -33,7 +33,7 @@ namespace Jitbit.Utils
 						foreach (var p in _dict)
 						{
 							if (p.Value.IsExpired())
-								_dict.TryRemove(p.Key, out _);
+								_dict.TryRemove(p);
 						}
 					}
 					finally


### PR DESCRIPTION
Prevent removal of items that were added during enumeration.

I think the same behaviour as in `TryGet` should also be here.

Just using a simplified invocation via `TryRemove` which uses the same `TryRemoveInternal` with `matchValue: true` as the `ICollection.Remove` (at least in .NET 6)

![image](https://user-images.githubusercontent.com/39300419/206713814-2c03863e-e73d-4b90-b3ed-381493cd3c81.png)
