### PR TITLE
Remove closure allocations in two methods

### DIFF
--- a/FastCache/FastCache.cs
+++ b/FastCache/FastCache.cs
@@ -64,7 +64,7 @@ namespace Jitbit.Utils
 		{
 			var ttlValue = new TtlValue(value, ttl);
 
-			_dict.AddOrUpdate(key, ttlValue, (k, v) => ttlValue);
+			_dict.AddOrUpdate(key, (k, c) => c, (k, v, c) => c, ttlValue);
 		}
 
 		/// <summary>
@@ -153,7 +153,7 @@ namespace Jitbit.Utils
 			if (TryGet(key, out var value))
 				return value;
 
-			return _dict.GetOrAdd(key, (k, v) => new TtlValue(valueFactory(k), v), ttl).Value;
+			return _dict.GetOrAdd(key, (k, v) => new TtlValue(v.valueFactory(k), v.ttl), (ttl, valueFactory)).Value;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Hi, I was benchmarking a few caching libraries and noticed two closure allocations which can be avoided.

1. `FastCache.GetOrAdd` was using the `TArg` overload of `ConcurrentDictionary` (as pointed out by #1 and fixed by ebef51eba27f9fd3882cf8e148dbb6823ed5dc57), but it was still capturing `valueFactory` variable. I changed `TArg` to a tuple of the two variables needed.
2. `FastCache.AddOrUpdate` could be similarly changed to use another overload and prevent capturing `ttlValue` variable.

I ran the project benchmark on my machine with the following results:
```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.1702)
12th Gen Intel Core i7-12800H, 1 CPU, 20 logical and 14 physical cores
.NET SDK=7.0.202
  [Host]   : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
  ShortRun : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  
```

**Main branch** (3e9a35a98d9004ff9fe30230eb1c7927b6557cc0)

|               Method |      Mean |      Error |   StdDev |   Gen0 | Allocated |
|--------------------- |----------:|-----------:|---------:|-------:|----------:|
|     DictionaryLookup |  57.49 ns |  11.028 ns | 0.604 ns |      - |         - |
|      FastCacheLookup |  55.94 ns |   5.386 ns | 0.295 ns |      - |         - |
|    MemoryCacheLookup | 347.25 ns | 135.332 ns | 7.418 ns | 0.0100 |     128 B |
|    FastCacheGetOrAdd |  81.88 ns |  12.146 ns | 0.666 ns | 0.0076 |      96 B |
|   FastCacheAddRemove |  73.22 ns |  21.811 ns | 1.196 ns | 0.0134 |     168 B |
| MemoryCacheAddRemove | 389.02 ns |  80.734 ns | 4.425 ns | 0.0257 |     328 B |


**This PR** (686fd0479d0443f055be4245cb464e9aa3722e73)

|               Method |      Mean |      Error |   StdDev |   Gen0 | Allocated |
|--------------------- |----------:|-----------:|---------:|-------:|----------:|
|     DictionaryLookup |  57.67 ns |   5.942 ns | 0.326 ns |      - |         - |
|      FastCacheLookup |  59.16 ns |  25.778 ns | 1.413 ns |      - |         - |
|    MemoryCacheLookup | 343.65 ns | 145.375 ns | 7.969 ns | 0.0100 |     128 B |
|    FastCacheGetOrAdd |  71.71 ns |  23.982 ns | 1.315 ns |      - |         - |
|   FastCacheAddRemove |  72.49 ns | 103.096 ns | 5.651 ns | 0.0063 |      80 B |
| MemoryCacheAddRemove | 369.58 ns |  83.251 ns | 4.563 ns | 0.0257 |     328 B |
